### PR TITLE
Option to disable verbose AR debug logging

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -12,4 +12,9 @@ DB = ActiveRecord::Base.connection
 
 if ENV["PLAYLISTER_ENV"] == "test"
   ActiveRecord::Migration.verbose = false
+
+  # The verbose logging of ActiveRecord database interactions during testing
+  # provides insight into ActiveRecord's inner workings, but makes the rspec output less legible.
+  # Uncomment the next line to disable this logging.
+  # ActiveRecord::Base.logger.level = Logger::INFO
 end


### PR DESCRIPTION
The verbose logging of ActiveRecord database interactions during testing provides insight into ActiveRecord's inner workings, but makes the rspec output less legible.

This commit adds a commented-out option to environment.rb to facilitate disabling this verbose logging, along with an explanatory comment.